### PR TITLE
agent: do not add taint for edge node automatically

### DIFF
--- a/pkg/controllers/agent/yurtcluster_controller.go
+++ b/pkg/controllers/agent/yurtcluster_controller.go
@@ -163,9 +163,6 @@ func (r *YurtClusterReconciler) reconcileEdgeNode(ctx context.Context, yurtClust
 		return ctrl.Result{}, errors.Errorf("can not convert node %q because it is in NotReady status", node.Name)
 	}
 
-	// add edge taint
-	util.EnsureEdgeTaintForNode(node)
-
 	// add edge label for node
 	node.Labels[projectinfo.GetEdgeWorkerLabelKey()] = "true"
 
@@ -176,9 +173,6 @@ func (r *YurtClusterReconciler) reconcileNormalNode(ctx context.Context, yurtClu
 	if controllersutil.IsNodeConvertOrRevertCompleted(node, yurtCluster) {
 		return ctrl.Result{}, nil
 	}
-
-	// remove edge taint if exists
-	util.RemoveEdgeTaintForNode(node)
 
 	// remove edge label from node labels
 	delete(node.Labels, projectinfo.GetEdgeWorkerLabelKey())

--- a/pkg/util/kubernetes.go
+++ b/pkg/util/kubernetes.go
@@ -48,12 +48,6 @@ const (
 	// SkipReconcileAnnotation defines the annotation which marks the object should not be reconciled
 	SkipReconcileAnnotation = "operator.openyurt.io/skip-reconcile"
 
-	// EdgeNodeTaintKey defines the taint key for edge node
-	EdgeNodeTaintKey = "node-role.openyurt.io/edge"
-
-	// EdgeNodeTaintEffect defines the taint effect for edge node
-	EdgeNodeTaintEffect = "NoSchedule"
-
 	// ControlPlaneLabel defines the label for control-plane node
 	ControlPlaneLabel = "node-role.kubernetes.io/master"
 )
@@ -349,35 +343,4 @@ func GetYurtComponentImageByType(yurtCluster *operatorv1alpha1.YurtCluster, imag
 		name = "unknown"
 	}
 	return fmt.Sprintf("%s/%s:%s", repository, name, tag)
-}
-
-// EnsureEdgeTaintForNode adds edge taint for node
-func EnsureEdgeTaintForNode(node *corev1.Node) {
-	found := false
-	for _, taint := range node.Spec.Taints {
-		if taint.Key == EdgeNodeTaintKey && taint.Effect == EdgeNodeTaintEffect {
-			found = true
-			break
-		}
-	}
-
-	if !found {
-		taint := corev1.Taint{
-			Key:    EdgeNodeTaintKey,
-			Effect: EdgeNodeTaintEffect,
-		}
-		node.Spec.Taints = append(node.Spec.Taints, taint)
-	}
-}
-
-// RemoveEdgeTaintForNode removes edge taint for node
-func RemoveEdgeTaintForNode(node *corev1.Node) {
-	var newTaints []corev1.Taint
-	for _, taint := range node.Spec.Taints {
-		if taint.Key == EdgeNodeTaintKey && taint.Effect == EdgeNodeTaintEffect {
-			continue
-		}
-		newTaints = append(newTaints, taint)
-	}
-	node.Spec.Taints = newTaints
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
https://github.com/openyurtio/openyurt/blob/master/CONTRIBUTING.md 
-->

#### What type of PR is this?
/kind cleanup

<!--
Add one of the following kinds:
> /kind bug
> /kind documentation
> /kind enhancement
> /kind good-first-issue
> /kind feature
> /kind question
> /kind design

Optionally add one or more of the following kinds if applicable:
> /sig ai
> /sig iot
> /sig network
> /sig storage
-->

#### What this PR does / why we need it:
agent: do not add taint for edge node automatically

REF: https://github.com/openyurtio/openyurt/pull/763

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
use this label to assign your reviewer
> /assign @your_reviewer
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
The yurtcluster-operator will not add the `node-role.openyurt.io/edge:NoSchedule` taint for the edge node.
```

#### Other Note
<!--
If your current PR is still working in process, start the PR title name with [WIP], such as: [WIP] add new crd for yurt-app-manager.
If the PR title name begins with [WIP], OpenYurt-Bot will add a do-not-merge/work-in-progress label for your PR automatically.
-->
